### PR TITLE
Add `labels` action argument with default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
   source-repo: 
     description: 'Source repository for the image that was built'
     required: true
+  labels:
+    description: 'A comma or newline separated list of labels.'
+    required: true
+    default: "automerge"
 runs:
   using: "composite"
   steps:
@@ -56,7 +60,7 @@ runs:
 
 
             This PR is auto-generated. 
-        labels: automerge
+        labels: ${{ inputs.labels }}
         
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This maintains the same value (automerge) as before so its a non breaking change. This allows us to override what labels are set or not set any.