### PR TITLE
Allow v4 on create-pull-request action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         kustomize edit set image ${{ inputs.image-name }}=${{ inputs.image-name }}:${{ inputs.tag }}
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4.0.0
+      uses: peter-evans/create-pull-request@v4
       with:
         path: infra
         token: ${{ inputs.token }}


### PR DESCRIPTION
Since we had this fixed to v4.0.0 we weren't getting minor updates. Recently, we've noticed the following output on builds using this action:

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

We've confirmed that it comes from this action and by just allowing v4, we'll pick up the fix. https://github.com/peter-evans/create-pull-request/issues/1298#issuecomment-1289717248

<img width="500" alt="Screen Shot 2022-12-28 at 10 58 30 AM" src="https://user-images.githubusercontent.com/198547/209838938-08f1c57d-42c7-41a0-b9a4-971e0d14fa08.png">
