### PR TITLE
Add kustomize-version input with working (5.1.1) default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,16 @@ inputs:
     description: 'A comma or newline separated list of labels.'
     required: true
     default: "automerge"
+  kustomize-version:
+    description: 'The kustomize version as allowed by the setup-kustomize action.'
+    required: true
+    default: "5.1.1"
 runs:
   using: "composite"
   steps:
     - uses: imranismail/setup-kustomize@v2
+      with:
+        kustomize-version: ${{ inputs.kustomize-version }}
 
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
There is an error with the archive format as part of the 5.2.0 release that is causing all our deployment builds to fail.

https://github.com/kubernetes-sigs/kustomize/issues/5396

Initial approach didn't work with GHA variables so we'll use a new input but default its value for backwards compatibility.