### PR TITLE
Update PR title with "image tag deployment" content

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
         delete-branch: true
         branch-suffix: random
         commit-message: Updating ${{ inputs.source-repo }} tag to ${{ inputs.tag }}
-        title: "${{ inputs.source-repo }} deployment"
+        title: "${{ inputs.source-repo }} image tag deployment"
         body: >
             Related to https://github.com/${{ inputs.source-repo }}/commit/${{ inputs.tag }}
 


### PR DESCRIPTION
Include more specific content ("image tag deployment") in the PR title which will appear in the email subject line so it can be easily targeted by an Outlook rule. These are automated so we want easy rules to handle them vs manually created infra PRs.